### PR TITLE
feat: add MCP starter (TypeScript + SDK scaffolding)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,40 +1,19 @@
-{
-  "name": "nexus6-uni-mcp-server",
-  "version": "1.1.1",
-  "private": true,
-  "license": "MIT",
-  "type": "module",
-  "scripts": {
-    "start:ui": "node server/server.js",
-    "dev:mcp": "tsx src/unified/server.ts",
-    "build": "tsc -p tsconfig.json",
-    "start:mcp": "node dist/unified/server.js",
-    "dev": "npm-run-all -p start:ui dev:mcp",
-    "type-check": "tsc --noEmit",
-    "lint": "eslint src/**/*.ts",
-    "format": "prettier --write src/**/*.ts",
-    "test": "vitest run",
-    "clean": "rimraf dist"
-  },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
-    "cors": "^2.8.5",
-    "express": "^4.19.2",
-    "ws": "^8.17.0",
-    "zod": "^3.23.8",
-    "dotenv": "^16.4.5",
-    "@octokit/rest": "^21.0.2",
-    "uuid": "^9.0.1"
-  },
-  "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0",
-    "eslint": "^8.57.1",
-    "prettier": "^3.3.3",
-    "typescript": "^5.6.3",
-    "vitest": "^2.0.5",
-    "tsx": "^4.15.7",
-    "npm-run-all": "^4.1.5",
-    "rimraf": "^5.0.10"
-  }
+﻿{
+    "name":  "nexus6-uni-mcp-server",
+    "version":  "1.0.0",
+    "type":  "module",
+    "scripts":  {
+                    "build":  "tsc -p .",
+                    "start":  "node dist/unified/server.js",
+                    "dev":  "node dist/unified/server.js"
+                },
+    "dependencies":  {
+                         "@modelcontextprotocol/sdk":  "^1.0.0",
+                         "zod":  "^3.22.2"
+                     },
+    "devDependencies":  {
+                            "@types/node":  "^24.3.1",
+                            "tsx":  "^4.7.0",
+                            "typescript":  "^5.4.0"
+                        }
 }

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,17 +1,25 @@
 export interface Config {
-  airtable: { apiKey: string; baseId: string };
-  github: { token: string; owner: string; repo: string };
+  airtable: {
+    apiKey: string;
+    baseId: string;
+  };
+  github: {
+    token: string;
+    owner: string;
+    repo: string;
+  };
 }
 
 export function loadConfig(): Config {
-  const apiKey  = process.env.AIRTABLE_API_KEY || "";
-  const baseId  = process.env.AIRTABLE_BASE_ID || "";
-  const ghToken = process.env.GITHUB_TOKEN || "";
-  const ghOwner = process.env.GITHUB_OWNER || "Link-Synapse";
-  const ghRepo  = process.env.GITHUB_REPO  || "nexus6-uni-mcp-server";
-
-  if (!apiKey || !baseId) console.warn("[env] Missing Airtable vars (AIRTABLE_API_KEY, AIRTABLE_BASE_ID)");
-  if (!ghToken) console.warn("[env] Missing GitHub token (GITHUB_TOKEN)");
-
-  return { airtable: { apiKey, baseId }, github: { token: ghToken, owner: ghOwner, repo: ghRepo } };
+  return {
+    airtable: {
+      apiKey: process.env.AIRTABLE_API_KEY!,
+      baseId: process.env.AIRTABLE_BASE_ID!
+    },
+    github: {
+      token: process.env.GITHUB_TOKEN!,
+      owner: process.env.GITHUB_OWNER!,
+      repo: process.env.GITHUB_REPO!
+    }
+  };
 }

--- a/src/github/adapter.ts
+++ b/src/github/adapter.ts
@@ -1,23 +1,44 @@
-import { Buffer } from "node:buffer";
-
 export class GitHubAdapter {
-  constructor(private token: string, private owner: string, private repo: string) {}
+  private token: string;
+  private baseUrl = "https://api.github.com";
 
-  private url(path: string) {
-    return `https://api.github.com/repos/${this.owner}/${this.repo}/contents/${encodeURIComponent(path)}`;
-  }
-  private headers() {
-    return { Authorization: `Bearer ${this.token}`, "User-Agent": "nexus6-uni-mcp",
-      Accept: "application/vnd.github+json", "Content-Type": "application/json" };
+  constructor(token: string) {
+    this.token = token;
   }
 
-  async createOrUpdateFile(path: string, content: string, message: string) {
+  async createOrUpdateFile(owner: string, repo: string, path: string, content: string, message: string) {
+    const url = `${this.baseUrl}/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`;
+
+    const res = await fetch(url, {
+      headers: { Authorization: `token ${this.token}`, "User-Agent": "n6-mcp" }
+    });
+
     let sha: string | undefined;
-    { const res = await fetch(this.url(path), { headers: this.headers() });
-      if (res.ok) { const js = await res.json(); sha = js.sha; } }
-    const body = { message, content: Buffer.from(content, "utf-8").toString("base64"), sha };
-    const put = await fetch(this.url(path), { method: "PUT", headers: this.headers(), body: JSON.stringify(body) });
-    if (!put.ok) { const txt = await put.text(); throw new Error(`GitHub write failed: ${put.status} ${put.statusText} — ${txt}`); }
-    return put.json();
+    if (res.status === 200) {
+      const json = await res.json();
+      sha = json.sha;
+    }
+
+    const body = {
+      message,
+      content: Buffer.from(content, "utf8").toString("base64"),
+      sha
+    };
+
+    const putRes = await fetch(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `token ${this.token}`,
+        "User-Agent": "n6-mcp",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (!putRes.ok) {
+      const text = await putRes.text();
+      throw new Error(`GitHub API error: ${putRes.status} ${putRes.statusText} — ${text}`);
+    }
+    return await putRes.json();
   }
 }

--- a/src/types/shim.d.ts
+++ b/src/types/shim.d.ts
@@ -1,0 +1,2 @@
+// Editor helper for Node builtins if needed (tsc uses @types/node)
+declare module "node:crypto";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "types": ["node"],
+    "outDir": "dist"
   },
   "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "dist"
+    "src/unified/**/*.ts",
+    "src/config/**/*.ts",
+    "src/airtable/**/*.ts",
+    "src/github/**/*.ts",
+    "src/types/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
- Introduced MCP-compliance starter pack
  - Added TypeScript config scoped to MCP files
  - Installed MCP SDK + Zod + TypeScript tooling
  - Added Airtable + GitHub adapters (skeletons)
  - Added unified MCP server entry (stdio transport)
- Created branch feat/mcp-compliance to isolate changes from main
- Dev script now runs the MCP server

Next steps:
- Replace any-typed handlers with real MCP SDK types
- Add Zod validation to adapter inputs
- Expand tools/resources per code review doc
