### PR TITLE
docs: add reviewer handout + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+<!-- What changed and why? -->
+
+## Linked Task(s)
+- Airtable Doc / Spec:
+
+## What's in this PR
+- [ ] New files at exact paths provided by Ax
+- [ ] Updates only
+- [ ] Other:
+
+## Testing / Verification
+1.
+2.
+3.
+
+## Screenshots (if UI)
+
+## Risks / Rollout
+- Risk: Low / Medium / High
+- Rollout plan:
+
+## Checklist
+- [ ] Paths exactly match Ax's post
+- [ ] No secrets committed
+- [ ] Docs updated if needed
+- [ ] Builds/starts locally (if applicable)

--- a/REVIEW_HANDOUT.md
+++ b/REVIEW_HANDOUT.md
@@ -1,0 +1,26 @@
+# Nexus6 MCP — Reviewer Handout
+
+Workflow
+1) Ax posts full files with exact Windows paths.
+2) Claude (GitHub MCP) creates a branch, adds files, commits, opens a PR.
+3) You review and merge. Specs can be mirrored in Airtable `Docs`.
+
+Daily Claude prompts
+
+Open repo + branch + PR
+> Open `Link-Synapse/nexus6-uni-mcp-server`, create branch `feature/<short-slug>`, add the files Ax provided at the exact paths, commit `feat: <summary>`, open a PR to `main`, and paste the PR link.
+
+Airtable upsert (optional)
+> In base `appM75fvKM3nYyOaF`, table `Docs`, upsert a record with Slug='<slug>', Status='Ready', and Content = the spec Ax provided.
+
+PR Review Checklist
+- [ ] Summary & scope are clear
+- [ ] Paths exactly match Ax's post
+- [ ] Builds locally (if applicable)
+- [ ] No secrets
+- [ ] Links to Airtable Doc (if used)
+- [ ] Tests/manual steps documented
+
+Rollback
+- Revert the PR via GitHub.
+- If conflict, follow-up PR with `_conflict-YYYYMMDD`.


### PR DESCRIPTION
## Summary
Adds documentation for the multi-AI collaborative review workflow and standardized PR template.

## Linked Task(s)
- Airtable Doc / Spec: N/A (workflow documentation)

## What's in this PR
- [x] New files at exact paths provided by Ax
- [ ] Updates only
- [ ] Other:

## Testing / Verification
1. Files added at exact specified paths
2. REVIEW_HANDOUT.md contains complete workflow instructions
3. PR template will auto-populate for future PRs

## Screenshots (if UI)
N/A - Documentation only

## Risks / Rollout
- Risk: Low
- Rollout plan: Immediate - documentation has no runtime impact

## Checklist
- [x] Paths exactly match Ax's post
- [x] No secrets committed
- [x] Docs updated if needed
- [x] Builds/starts locally (if applicable)